### PR TITLE
Fix press outside registration lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,6 @@
 
 ### 🐛 Bug fixes
 
+- Register press-outside targets and blockers with `useNow` instead of render-time memo hooks.
+
 ### 💡 Others

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "expo": "*",
         "react": "*",
         "react-native": "*",
-        "set-state-compare": ">= 1.0.61"
+        "set-state-compare": ">= 1.0.86"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -8928,9 +8928,9 @@
       }
     },
     "node_modules/fetching-object": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/fetching-object/-/fetching-object-1.0.4.tgz",
-      "integrity": "sha512-8qCT2cu0CzDcgYO0cp03wLP3Xoef4+XhB97/+uUFqFMSWc3t54qufUMLcsJ+bAUjkaHcczmzm2MlEaLdAvarOA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/fetching-object/-/fetching-object-1.0.7.tgz",
+      "integrity": "sha512-DVBXLz6EijDqntTWpw/4m/77yFfPXGUVrcTI0fQXJWS9Zu7ljgKVhIi7NI+jrcqBxsJFpN+vM7spyX2JGKEiAA==",
       "license": "ISC",
       "peer": true
     },
@@ -15197,14 +15197,14 @@
       }
     },
     "node_modules/set-state-compare": {
-      "version": "1.0.61",
-      "resolved": "https://registry.npmjs.org/set-state-compare/-/set-state-compare-1.0.61.tgz",
-      "integrity": "sha512-HvGkYPjpbvcnI07bMc/XTn8w/+Nm8Z/6SpUnvCq6nUGiQK0P/TbAs9tYkbfhaGILJPVunOb7HNxIQjnJm6dbmQ==",
+      "version": "1.0.86",
+      "resolved": "https://registry.npmjs.org/set-state-compare/-/set-state-compare-1.0.86.tgz",
+      "integrity": "sha512-0Gl2qXougZnPCC36d5n/OyRCiKowlhSlGr23Weo1TSyrsb6Iiak5roUAY6CuHII4u5FQtczsh0EFANHgvw1jhg==",
       "license": "ISC",
       "peer": true,
       "dependencies": {
         "diggerize": "^1.0.5",
-        "fetching-object": ">= 1.0.2"
+        "fetching-object": "^1.0.7"
       },
       "peerDependencies": {
         "prop-types": ">= 15.8.1",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
     "expo": "*",
     "react": "*",
     "react-native": "*",
-    "set-state-compare": ">= 1.0.61"
+    "set-state-compare": ">= 1.0.86"
   }
 }

--- a/src/use-press-outside-blocker.js
+++ b/src/use-press-outside-blocker.js
@@ -1,4 +1,5 @@
 import React from "react"
+import useNow from "set-state-compare/build/use-now.js"
 import usePressOutsideContext from "./use-press-outside-context"
 import UUID from "pure-uuid"
 
@@ -9,19 +10,31 @@ import UUID from "pure-uuid"
  */
 export default function usePressOutsideBlocker(blockerRef) {
   const value = usePressOutsideContext()
-  const id = React.useMemo(() => new UUID(4).format(), [])
+  const registrationRef = React.useRef(/** @type {{id: string, provider: import("./provider.jsx").OutsideEyeContextValueType["clickOutsideProvider"]} | null} */ (null))
 
   if (!value) {
     throw new Error("Not inside click outside context")
   }
 
-  React.useMemo(() => {
-    value?.clickOutsideProvider?.registerBlocker(id, blockerRef)
-  }, [blockerRef, id, value?.clickOutsideProvider])
+  const {clickOutsideProvider} = value
+
+  useNow(() => {
+    if (registrationRef.current) {
+      registrationRef.current.provider.unregisterBlocker(registrationRef.current.id)
+    }
+
+    const id = new UUID(4).format()
+
+    clickOutsideProvider.registerBlocker(id, blockerRef)
+    registrationRef.current = {id, provider: clickOutsideProvider}
+  }, [blockerRef, clickOutsideProvider])
 
   React.useEffect(() => {
     return () => {
-      value?.clickOutsideProvider?.unregisterBlocker(id)
+      if (registrationRef.current) {
+        registrationRef.current.provider.unregisterBlocker(registrationRef.current.id)
+        registrationRef.current = null
+      }
     }
-  }, [blockerRef, id, value?.clickOutsideProvider])
+  }, [])
 }

--- a/src/use-press-outside.js
+++ b/src/use-press-outside.js
@@ -1,4 +1,5 @@
 import React from "react"
+import useNow from "set-state-compare/build/use-now.js"
 import usePressOutsideContext from "./use-press-outside-context"
 import UUID from "pure-uuid"
 
@@ -9,19 +10,31 @@ import UUID from "pure-uuid"
  */
 export default function usePressOutside(childRef, onPressOutside) {
   const value = usePressOutsideContext()
-  const id = React.useMemo(() => new UUID(4).format(), [])
+  const registrationRef = React.useRef(/** @type {{id: string, provider: import("./provider.jsx").OutsideEyeContextValueType["clickOutsideProvider"]} | null} */ (null))
 
   if (!value) {
     throw new Error("Not inside click outside context")
   }
 
-  React.useMemo(() => {
-    value?.clickOutsideProvider?.register(id, childRef, onPressOutside)
-  }, [childRef, id, onPressOutside, value?.clickOutsideProvider])
+  const {clickOutsideProvider} = value
+
+  useNow(() => {
+    if (registrationRef.current) {
+      registrationRef.current.provider.unregister(registrationRef.current.id)
+    }
+
+    const id = new UUID(4).format()
+
+    clickOutsideProvider.register(id, childRef, onPressOutside)
+    registrationRef.current = {id, provider: clickOutsideProvider}
+  }, [childRef, clickOutsideProvider, onPressOutside])
 
   React.useEffect(() => {
     return () => {
-      value?.clickOutsideProvider?.unregister(id)
+      if (registrationRef.current) {
+        registrationRef.current.provider.unregister(registrationRef.current.id)
+        registrationRef.current = null
+      }
     }
-  }, [childRef, id, onPressOutside, value?.clickOutsideProvider])
+  }, [])
 }


### PR DESCRIPTION
## Summary
- replace render-time `useMemo` registration with `useNow` for immediate press-outside registration
- keep unregister cleanup tied to the latest registration ref on unmount
- require `set-state-compare` >= 1.0.86 for `useNow`

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run test -- --passWithNoTests` (package currently has no tests)